### PR TITLE
Load common phrases

### DIFF
--- a/addons/sourcemod/scripting/myranks.sp
+++ b/addons/sourcemod/scripting/myranks.sp
@@ -57,6 +57,7 @@ public void OnPluginStart()
 {
     CreateGlobalForwards();
     LoadTranslations("myranks.phrases");
+    LoadTranslations("common.phrases.txt"); // For FindTarget
 
     RegisterCommands();
 }


### PR DESCRIPTION
They are needed for errors that happen in case you try to target an
invalid player with the FindTarget function, which is used in the !rank
command for example. Not having this file loaded will throw errors every
time that someone uses !rank <player name> with an invalid name.