### PR TITLE
Kicker plugin improvements (and version 1.2.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ Overrides
 
 ## Changelog
 
+* **1.2.4** 14.10.2021
+  - Handle race condition in Kicker plugin.
+    Properly check that both admin and score have been loaded before checking if the player should be kicked. Should
+    solve issues where clients with reserved slot gets kicked because their admin rights are not loaded at the time the
+    score is loaded and the kicker triggers.
+  - Use correct skillgroup in kick message in Kicker
+    Previously the message would say "Needed:" and then the players skillgroup. Now it will say both the players
+    skillgroup, and the one that is actually needed.
+
 * **1.2.3** 07.03.2021
   - Calculate score with low priority in initial setup.
     Separates the player insertion and initial score load, so that we can do the important stuff with high prio, and the

--- a/addons/sourcemod/scripting/include/myranks.inc
+++ b/addons/sourcemod/scripting/include/myranks.inc
@@ -4,7 +4,7 @@
 #endif
 #define _myrank_included_
 
-#define MYRANK_VERSION "1.2.3"
+#define MYRANK_VERSION "1.2.4"
 
 #define MYRANK_SG_NAME_MAXLENGTH 24
 #define MYRANK_SG_PERCENTAGE_MAXLENGTH 8

--- a/addons/sourcemod/scripting/include/myranks.inc
+++ b/addons/sourcemod/scripting/include/myranks.inc
@@ -75,4 +75,4 @@ forward void Myrank_OnMaxScoreChange(int newScore, int mode);
  * @param mode        In which mode the score changed
 */
 
-forward void Myrank_OnScoreChange(int client, int newScore, int mode);
+forward void Myrank_OnInitialScoreLoad(int client, int newScore, int mode);

--- a/addons/sourcemod/scripting/myranks-kicker.sp
+++ b/addons/sourcemod/scripting/myranks-kicker.sp
@@ -95,9 +95,11 @@ public void KickIfNotAllowed(int client)
     int skillGroup = Myrank_GetSkillGroup(newScore, mode);
 
     char skillGroupName[MYRANK_SG_NAME_MAXLENGTH];
+    char neededSkillGroupName[MYRANK_SG_NAME_MAXLENGTH];
     Myrank_GetSkillGroupName(skillGroup, skillGroupName);
+    Myrank_GetSkillGroupName(gCV_myrank_minimum_allowed_skillgroup.IntValue, neededSkillGroupName);
 
     if (skillGroup < gCV_myrank_minimum_allowed_skillgroup.IntValue) {
-        KickClient(client, "%t", "Skillgroup Kick", gC_ModeNamesShort[mode], skillGroupName);
+        KickClient(client, "%t", "Skillgroup Kick", gC_ModeNamesShort[mode], skillGroupName, neededSkillGroupName);
     }
 }

--- a/addons/sourcemod/translations/myranks-kicker.phrases.txt
+++ b/addons/sourcemod/translations/myranks-kicker.phrases.txt
@@ -9,7 +9,7 @@
 	"Skillgroup Kick"
 	{
 		// You are not high enough skillgroup in mode: KZT. Needed: Skilled+
-		"#format"	"{1:s},{2:s}"
-		"en"		"You are not high enough skillgroup in mode: {1}. Needed: {2}"
+		"#format"	"{1:s},{2:s},{3:s}"
+		"en"		"You are not high enough skillgroup in mode: {1}. Your skillgroup: {2}. Needed: {3}"
 	}
 }


### PR DESCRIPTION
- Handle race condition in Kicker plugin.
  Properly check that both admin and score have been loaded before checking if the player should be kicked. Should
  solve issues where clients with reserved slot gets kicked because their admin rights are not loaded at the time the
  score is loaded and the kicker triggers.

- Use correct skillgroup in kick message in Kicker.
  Previously the message would say "Needed:" and then the players skillgroup. Now it will say both the players
  skillgroup, and the one that is actually needed.

- Fixed a bad copy-paste in .inc file's forward names.